### PR TITLE
Choosing db configuration method based on what is available

### DIFF
--- a/lib/valkyrie/persistence/postgres/metadata_adapter.rb
+++ b/lib/valkyrie/persistence/postgres/metadata_adapter.rb
@@ -31,8 +31,18 @@ module Valkyrie::Persistence::Postgres
     # @return [Valkyrie::ID]
     def id
       @id ||= begin
-        to_hash = "#{resource_factory.orm_class.connection_config['host']}:#{resource_factory.orm_class.connection_config['database']}"
+        to_hash = "#{connection_configuration[:host]}:#{connection_configuration[:database]}"
         Valkyrie::ID.new(Digest::MD5.hexdigest(to_hash))
+      end
+    end
+
+    private
+
+    def connection_configuration
+      if resource_factory.orm_class.respond_to?(:connection_db_config)
+        resource_factory.orm_class.connection_db_config.configuration_hash
+      else
+        resource_factory.orm_class.connection_config
       end
     end
   end

--- a/spec/valkyrie/persistence/postgres/metadata_adapter_spec.rb
+++ b/spec/valkyrie/persistence/postgres/metadata_adapter_spec.rb
@@ -7,10 +7,24 @@ RSpec.describe Valkyrie::Persistence::Postgres::MetadataAdapter do
   it_behaves_like "a Valkyrie::MetadataAdapter"
 
   describe "#id" do
+    let(:db_config) { adapter.send(:connection_configuration) }
+
     it "creates an md5 hash from the host and database name" do
-      to_hash = "#{ActiveRecord::Base.connection_config['host']}:#{ActiveRecord::Base.connection_config['database']}"
+      to_hash = "#{db_config[:host]}:#{db_config[:database]}"
       expected = Digest::MD5.hexdigest to_hash
       expect(adapter.id.to_s).to eq expected
+    end
+  end
+
+  describe "#connection_configuration" do
+    let(:config) { adapter.send(:connection_configuration) }
+
+    it 'returns hash with :host key' do
+      expect(config[:host]).not_to be_nil
+    end
+
+    it 'returns hash with :database key' do
+      expect(config[:database]).not_to be_nil
     end
   end
 end


### PR DESCRIPTION
In Rails 7, connection_config was deprecated in favor or connection_db_config.